### PR TITLE
Make api.save/load work with numbers rather than {value: number}

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -17,29 +17,23 @@ const flakify = <T>(f: () => T): Promise<T> =>
       }, 200 + Math.random() * 2000) // tslint:disable-line
   );
 
-type Counter = {
-  value: number;
-};
-
 export type Api = {
-  save(x: Counter): Promise<null>;
-  load(): Promise<Counter>;
+  save(x: number): Promise<null>;
+  load(): Promise<number>;
 };
 
 export const api: Api = {
-  save: (counter: Counter): Promise<null> =>
+  save: (counter: number): Promise<null> =>
     flakify(() => {
-      localStorage.setItem('__counterValue', counter.value.toString());
+      localStorage.setItem('__counterValue', counter.toString());
       return null;
     }),
-  load: (): Promise<Counter> =>
+  load: (): Promise<number> =>
     flakify(() => {
       const storedValue = parseInt(
         localStorage.getItem('__counterValue') || '',
         10
       );
-      return {
-        value: storedValue || 0,
-      };
+      return storedValue || 0;
     }),
 };


### PR DESCRIPTION
Hello - running the example as is gives an error on loading. 

`api.save(...)` gets passed a number:

https://github.com/meandmax/redux-loop-ts-example/blob/00cc41c2ccb7ebc4abf07abb689380b3e3666324/src/reducers/index.ts#L43-L47

https://github.com/meandmax/redux-loop-ts-example/blob/00cc41c2ccb7ebc4abf07abb689380b3e3666324/src/actions/index.ts#L46-L51

but expects a `Counter`:

https://github.com/meandmax/redux-loop-ts-example/blob/00cc41c2ccb7ebc4abf07abb689380b3e3666324/src/api.ts#L30-L34

Similarly, `api.load()` resolves a `Counter`:

https://github.com/meandmax/redux-loop-ts-example/blob/00cc41c2ccb7ebc4abf07abb689380b3e3666324/src/api.ts#L35-L44

but the action expects a number:

https://github.com/meandmax/redux-loop-ts-example/blob/00cc41c2ccb7ebc4abf07abb689380b3e3666324/src/actions/index.ts#L72-L77

This then leads to the state shape being wrong, and the element refusing to render (Objects are not valid React children).

This commit gets rid of `Counter` and has the api just deal with numbers.